### PR TITLE
Remove leftover debugger statement in leveringsRoute.js

### DIFF
--- a/src/main/resources/static/js/leveringsRoute.js
+++ b/src/main/resources/static/js/leveringsRoute.js
@@ -58,8 +58,6 @@ bevestigBtn.addEventListener("click", async () => {
     const articles = JSON.parse(sessionStorage.getItem("articles") || "[]");
     const incomingDeliveryId = parseInt(sessionStorage.getItem("incomingDeliveryId"));
 
-    debugger;
-
     for (const row of rows) {
         const naam = row.cells[2].innerText;
         const aantal = parseInt(row.cells[3].innerText);


### PR DESCRIPTION
The debugger statement was unintentionally left in the code and has now been removed. This cleanup improves code readability and prevents unwanted interruptions during execution.